### PR TITLE
Fix login to churchtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /ctldap.config
 /ctldap.sh
 /node_modules
-.idea/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /ctldap.config
 /ctldap.sh
 /node_modules
+.idea/

--- a/ctldap.js
+++ b/ctldap.js
@@ -66,7 +66,7 @@ function apiLogin() {
       "json": true
     }).then(function (result) {
       if (result.status !== "success") {
-        throw result.message;
+        throw new Error(result.data);;
       }
       // clear login promise
       loginPromise = null;
@@ -100,7 +100,7 @@ function apiPost(func, data, triedLogin) {
             return apiPost(func, data, true);
           });
         }
-        throw result.message;
+        throw new Error(result.data);
       }
       return result.data;
   });
@@ -372,6 +372,12 @@ server.search("o=" + config.ldap_base_dn, searchLogging, authorize, requestUsers
 }, sendUsers, sendGroups, endSuccess);
 
 // Start LDAP server
-server.listen(parseInt(config.ldap_port), function() {
-  console.log('ChurchTools-LDAP-Wrapper listening @ %s', server.url);
-});
+apiLogin()
+  .then(function () {
+    server.listen(parseInt(config.ldap_port), function() {
+        console.log('ChurchTools-LDAP-Wrapper listening @ %s', server.url);
+    });
+  })
+  .catch(function (error) {
+    console.log("Error at login to ChurchTools: " + error);
+  });


### PR DESCRIPTION
Hi Michael,
wir haben den ctldap jetzt bei uns für die FeG Karlsruhe im Einsatz. Dabei ist mir aufgefallen, daß der ctldap den apiLogin erst ausführt, wenn der apiPost fehlschlägt. Allerdings klappt das nicht immer, da nicht unter allen Umständen ein "Session expired!" zurückkommt. Für den Fall, daß der neu eingetragenen API-User normal ausgeloggt ist, wird das apiLogin dann gar nicht aufgerufen. Stattdessen kommt nur ein wenig hilfreicher Authorisierungsfehler zurück (keine Berechtigung für "administer persons").
Die Lösung liegt darin, immer zuerst einen apiLogin zu machen, bevor der LDAP-Server gestartet wird. So können auch fehlerhafter API-Credentials direkt erkannt werden (falls der Login fehlschlägt).
Der Pull-Request setzt diesen Ansatz um.
Viele Grüße,
Matthias