### PR TITLE
Admin Only Login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ RUN mkdir /app && chown node:node /app
 USER node
 WORKDIR /app
 
-COPY . .
+# copy package.json first to use docker layer cache
+COPY package.json .
 RUN npm install
+COPY . .
 
 EXPOSE 1389
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LDAP Wrapper for ChurchTools v2.0
+# LDAP Wrapper for ChurchTools v2.1
 
 This software acts as an LDAP server for ChurchTools >= 3.25.0
 

--- a/ctldap.js
+++ b/ctldap.js
@@ -384,7 +384,7 @@ server.bind("ou=users,o=" + config.ldap_base_dn, function (req, res, next) {
 // Search implementation for user search
 server.search("ou=users,o=" + config.ldap_base_dn, searchLogging, authorize, requestUsers, function (req, res, next) {
   if (config.debug) {
-    console.log("[DEBUG] request for users");
+    console.log("[DEBUG] request for users " + req);
   }
   req.checkAll = req.scope !== "base";
   return next();
@@ -393,7 +393,7 @@ server.search("ou=users,o=" + config.ldap_base_dn, searchLogging, authorize, req
 // Search implementation for group search
 server.search("ou=groups,o=" + config.ldap_base_dn, searchLogging, authorize, requestGroups, function (req, res, next) {
   if (config.debug) {
-    console.log("[DEBUG] request for groups");
+    console.log("[DEBUG] request for groups " + req);
   }
   req.checkAll = req.scope !== "base";
   return next();
@@ -402,7 +402,7 @@ server.search("ou=groups,o=" + config.ldap_base_dn, searchLogging, authorize, re
 // Search implementation for user and group search
 server.search("o=" + config.ldap_base_dn, searchLogging, authorize, requestUsers, requestGroups, function (req, res, next) {
   if (config.debug) {
-    console.log("[DEBUG] request for users and groups combined");
+    console.log("[DEBUG] request for users and groups combined " + req);
   }
   req.checkAll = req.scope === "sub";
   return next();
@@ -411,7 +411,7 @@ server.search("o=" + config.ldap_base_dn, searchLogging, authorize, requestUsers
 // Search implementation for basic search for Directory Information Tree and the LDAP Root DSE
 server.search('', function(req, res, next) {
   if (config.debug) {
-    console.log("[DEBUG] empty request, return directory information");
+    console.log("[DEBUG] empty request, return directory information " + req);
   }
   var obj = {
           "attributes":{

--- a/ctldap.js
+++ b/ctldap.js
@@ -265,7 +265,7 @@ function requestGroups (req, res, next) {
 function authorize(req, res, next) {
   if (!req.connection.ldap.bindDN.equals(adminDn)) {
     console.log("Rejected search without proper binding!");
-    return next(new ldap.InsufficientAccessRightsError());
+    // return next(new ldap.InsufficientAccessRightsError());
   }
   return next();
 }


### PR DESCRIPTION
Hello @milux 
the current version of Rocketchat requires, that an user can login to LDAP directly (exact request provided below). That means i needed to deactivate the admin-only login. See commit c37e75c.

**Normal successful Request:**
```
{
  "messageID": 2,
  "protocolOp": "SearchRequest",
  "baseObject": {
    "rdns": [
      {
        "o": "churchtools"
      }
    ],
    "rdnSpaced": false,
    "length": 1
  },
  "scope": "sub",
  "derefAliases": 0,
  "sizeLimit": 100000,
  "timeLimit": 10 ,
  "typesOnly": false,
  "filter": "(&(&(objectclass=ctperson))(|(cn=person@mail.de)(mail=person@mail.de)))",
  "attributes": [],
  "controls": []
}
```


**New RocketChat unsuccessful Request:**
```
{
  "messageID": 4,
  "protocolOp": "SearchRequest",
  "baseObject": {
    "rdns": [
      {
        "cn": "myusername"
      },
      {
        "ou": "users"
      },
      {
        "o": "churchtools"
      }
    ],
    "rdnSpaced": true,
    "length": 3
  },
  "scope": "sub",
  "derefAliases": 0,
  "sizeLimit": 0,
  "timeLimit": 10,
  "typesOnly": false,
  "filter": "(objectclass=*)",
  "attributes": [],
  "controls": []
}
```

I am not sure, why credentials are limited to root. At least, if LDAP is in a private network. (It is in my case). What do you think about that issue?

Thanks
Simon
