### PR TITLE
Fetch Persons and Groups paginated

### DIFF
--- a/ctldap.js
+++ b/ctldap.js
@@ -527,6 +527,9 @@ ldap.filters.SubstringFilter.prototype.matches = function (target, strictAttrCas
   return false;
 };
 
+ldap.ExtensibleFilter.super_.prototype.matches = function() {
+}
+
 
 // Start LDAP server
 server.listen(parseInt(config.ldapPort), config.ldapIp, () => {

--- a/sftp-config.json
+++ b/sftp-config.json
@@ -1,0 +1,46 @@
+{
+    // The tab key will cycle through the settings when first created
+    // Visit https://codexns.io/products/sftp_for_subime/settings for help
+    
+    // sftp, ftp or ftps
+    "type": "sftp",
+
+    "save_before_upload": true,
+    "upload_on_save": true,
+    "sync_down_on_open": false,
+    "sync_skip_deletes": false,
+    "sync_same_age": true,
+    "confirm_downloads": false,
+    "confirm_sync": true,
+    "confirm_overwrite_newer": false,
+    
+    "host": "192.168.61.181",
+    "user": "feg",
+    "password": "Rp1t17f",
+    //"port": "22",
+    
+    "remote_path": "/home/feg/ctldap",
+    "ignore_regexes": [
+        "\\.sublime-(project|workspace)", "sftp-config(-alt\\d?)?\\.json",
+        "sftp-settings\\.json", "/venv/", "\\.svn/", "\\.hg/", "\\.git/",
+        "\\.bzr", "_darcs", "CVS", "\\.DS_Store", "Thumbs\\.db", "desktop\\.ini"
+    ],
+    //"file_permissions": "664",
+    //"dir_permissions": "775",
+    
+    //"extra_list_connections": 0,
+
+    "connect_timeout": 30,
+    //"keepalive": 120,
+    //"ftp_passive_mode": true,
+    //"ftp_obey_passive_host": false,
+    //"ssh_key_file": "~/.ssh/id_rsa",
+    //"sftp_sudo": false,
+    //"sftp_flags": ["-F", "/path/to/ssh_config"],
+    
+    //"preserve_modification_times": false,
+    //"remote_time_offset_in_hours": 0,
+    //"remote_encoding": "utf-8",
+    //"remote_locale": "C",
+    //"allow_config_upload": false,
+}


### PR DESCRIPTION
Fetch all persons and groups via the paginated API to fix the Issue with Churchtools 3.100, where the limit -1 isn't possible anymore for groups, see #43 